### PR TITLE
Bugfix for ipv6 addresses

### DIFF
--- a/format.go
+++ b/format.go
@@ -190,7 +190,7 @@ var requestHttpProto = FormatWriteFunc(func(dst io.Writer, ctx LogCtx) error {
 
 var requestRemoteAddr = FormatWriteFunc(func(dst io.Writer, ctx LogCtx) error {
 	addr := ctx.Request().RemoteAddr
-	if i := strings.IndexByte(addr, ':'); i > -1 {
+	if i := strings.LastIndexByte(addr, ':'); i > -1 {
 		addr = addr[:i]
 	}
 	v := valueOf(addr, dashValue)


### PR DESCRIPTION
When the remote address is an ipv6 address, Request().RemoteAddr is of the form "[::1]:51111", thus the previous code resulted in a logged IP address of "[" instead of "[::1]"