### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ func main() {
   s.HandleFunc("/", handleIndex)
   s.HandleFunc("/foo", handleFoo)
 
-  http.ListenAndServe(":8080", apachelog.CombinedLog.Wrap(s, os.Stderr))
+  http.ListenAndServe(":8080", apachelog.CombinedLog.Wrap(&s, os.Stderr))
 }
 ```
 


### PR DESCRIPTION
Current code in README raises an error:
```
❯ go build main.go
# command-line-arguments
./main.go:15:57: cannot use s (type http.ServeMux) as type http.Handler in argument to apachelog.CombinedLog.Wrap:
	http.ServeMux does not implement http.Handler (ServeHTTP method has pointer receiver)
```
This PR fixes it.