### PR TITLE
make ResponseWriter an http.Flusher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 sudo: false
 go:
-    - 1.9.x
-    - 1.10.x
+    - 1.11.x
+    - 1.12.x
     - tip

--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -15,15 +15,11 @@ type ResponseWriter struct {
 	responseContentLength int64
 	responseStatus        int
 	responseWriter        http.ResponseWriter
-	flush                 func()
 }
 
 func GetResponseWriter(w http.ResponseWriter) *ResponseWriter {
 	rw := responseWriterPool.Get().(*ResponseWriter)
 	rw.responseWriter = w
-	if f, ok := w.(http.Flusher); ok {
-		rw.flush = f.Flush
-	}
 	return rw
 }
 
@@ -68,7 +64,7 @@ func (rw *ResponseWriter) WriteHeader(status int) {
 }
 
 func (rw *ResponseWriter) Flush() {
-	if rw.flush != nil {
-		rw.flush()
+	if f, ok := rw.responseWriter.(http.Flusher); ok {
+		f.Flush()
 	}
 }

--- a/internal_test.go
+++ b/internal_test.go
@@ -123,7 +123,7 @@ func TestFlusher(t *testing.T) {
 			}
 			break
 		}
-		t.Logf("Response body %d: %d %s", i, n, buf)
+		t.Logf("Response body %d: %d %s", i, n, buf[:n])
 		if !assert.Equal(t, []byte(lines[i]), buf[:n], "wrong response body") {
 			return
 		}

--- a/internal_test.go
+++ b/internal_test.go
@@ -95,7 +95,7 @@ func TestFlusher(t *testing.T) {
 			if f, ok := w.(http.Flusher); ok {
 				f.Flush()
 			}
-			time.Sleep(1)
+			time.Sleep(time.Microsecond)
 		}
 	})
 
@@ -117,6 +117,12 @@ func TestFlusher(t *testing.T) {
 	var i int
 	for {
 		n, err := resp.Body.Read(buf)
+		if n == 0 {
+			if !assert.Equal(t, len(lines)-1, i-1, "wrong number of chunks") {
+				return
+			}
+			break
+		}
 		t.Logf("Response body %d: %d %s", i, n, buf)
 		if !assert.Equal(t, []byte(lines[i]), buf[:n], "wrong response body") {
 			return


### PR DESCRIPTION
I am trying to write a server that emits chunks of the output as they're available, but this requires that the `ResponseWriter` in use be an `http.Flusher`, and the one created by `ApacheLog.Wrap()` isn't.

This PR makes it so. The downside is that it's always an `http.Flusher`, even if the underlying `ResponseWriter` isn't, which could be confusing for consumers (though nothing should break).